### PR TITLE
feat(heroes): add power stats with radar chart and form sliders

### DIFF
--- a/src/app/core/mocks/heroes.mock.ts
+++ b/src/app/core/mocks/heroes.mock.ts
@@ -1,6 +1,27 @@
 import { EPublisher } from '../models/enums/publisher.enum';
-import { IHero } from '../models/interfaces/hero.interface';
+import { IHero, IPowerStats } from '../models/interfaces/hero.interface';
 import { v4 as uuidv4 } from 'uuid';
+
+const HERO_POWER_STATS: Record<string, IPowerStats> = {
+  'dc-batman':            { strength: 35, speed: 27, intelligence: 100, durability: 44, combat: 100, power: 28 },
+  'dc-superman':          { strength: 100, speed: 96, intelligence: 94, durability: 100, combat: 85, power: 100 },
+  'dc-flash':             { strength: 48, speed: 100, intelligence: 88, durability: 50, combat: 70, power: 80 },
+  'dc-green-lantern':     { strength: 80, speed: 90, intelligence: 80, durability: 80, combat: 70, power: 100 },
+  'dc-green-arrow':       { strength: 28, speed: 25, intelligence: 75, durability: 28, combat: 90, power: 10 },
+  'dc-wonder-woman':      { strength: 95, speed: 90, intelligence: 88, durability: 90, combat: 100, power: 95 },
+  'dc-martian-manhunter': { strength: 100, speed: 85, intelligence: 100, durability: 90, combat: 85, power: 100 },
+  'dc-robin':             { strength: 28, speed: 27, intelligence: 63, durability: 28, combat: 85, power: 10 },
+  'marvel-spider-man':    { strength: 55, speed: 55, intelligence: 90, durability: 55, combat: 80, power: 60 },
+  'marvel-captain-america': { strength: 60, speed: 50, intelligence: 69, durability: 60, combat: 100, power: 30 },
+  'marvel-iron-man':      { strength: 85, speed: 75, intelligence: 100, durability: 85, combat: 64, power: 85 },
+  'marvel-thor':          { strength: 100, speed: 92, intelligence: 80, durability: 100, combat: 90, power: 100 },
+  'marvel-hulk':          { strength: 100, speed: 65, intelligence: 25, durability: 100, combat: 85, power: 98 },
+  'marvel-wolverine':     { strength: 55, speed: 38, intelligence: 63, durability: 100, combat: 95, power: 45 },
+  'marvel-daredevil':     { strength: 28, speed: 27, intelligence: 63, durability: 28, combat: 95, power: 10 },
+  'marvel-hawkeye':       { strength: 28, speed: 27, intelligence: 69, durability: 28, combat: 90, power: 10 },
+  'marvel-cyclops':       { strength: 28, speed: 27, intelligence: 75, durability: 28, combat: 85, power: 80 },
+  'marvel-silver-surfer': { strength: 100, speed: 100, intelligence: 88, durability: 100, combat: 80, power: 100 },
+};
 
 export const HEROES_MOCK: IHero[] = [
   {
@@ -237,4 +258,5 @@ export const HEROES_LIST = HEROES_MOCK.map((hero) => ({
     imgFA: `heroes/${hero.key}/img-fa.jpg`,
     imgHero: `heroes/${hero.key}/img-hero.png`,
   },
+  powerStats: HERO_POWER_STATS[hero.key],
 }));

--- a/src/app/core/models/class/hero.class.ts
+++ b/src/app/core/models/class/hero.class.ts
@@ -1,5 +1,5 @@
 import { EPublisher } from '../enums/publisher.enum';
-import { IFileManager, IHero } from '../interfaces/hero.interface';
+import { DEFAULT_POWER_STATS, IFileManager, IHero, IPowerStats } from '../interfaces/hero.interface';
 
 export class HeroModel implements IHero {
   id: string;
@@ -12,6 +12,7 @@ export class HeroModel implements IHero {
   originators: string[];
   description: string;
   fileManager?: IFileManager;
+  powerStats: IPowerStats;
 
   constructor(data?: IHero) {
     this.id = data?.id || '';
@@ -24,5 +25,6 @@ export class HeroModel implements IHero {
     this.originators = data?.originators || [];
     this.description = data?.description || '';
     this.fileManager = data?.fileManager || undefined;
+    this.powerStats = data?.powerStats ?? { ...DEFAULT_POWER_STATS };
   }
 }

--- a/src/app/core/models/interfaces/hero.interface.ts
+++ b/src/app/core/models/interfaces/hero.interface.ts
@@ -8,6 +8,24 @@ export interface IFileManager {
 
 export interface IOriginators {}
 
+export interface IPowerStats {
+  strength: number;      // Fuerza       0-100
+  speed: number;         // Velocidad     0-100
+  intelligence: number;  // Inteligencia  0-100
+  durability: number;    // Durabilidad   0-100
+  combat: number;        // Combate       0-100
+  power: number;         // Poder         0-100
+}
+
+export const DEFAULT_POWER_STATS: IPowerStats = {
+  strength: 50,
+  speed: 50,
+  intelligence: 50,
+  durability: 50,
+  combat: 50,
+  power: 50,
+};
+
 export interface IHero {
   id: string;
   key: string;
@@ -19,6 +37,7 @@ export interface IHero {
   originators: string[];
   description: string;
   fileManager?: IFileManager;
+  powerStats?: IPowerStats;
 }
 
 export interface IHeroFilters {

--- a/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.css
+++ b/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.css
@@ -1,0 +1,97 @@
+.radar-card {
+  background: white;
+  border: 1px solid var(--app-border);
+  border-radius: 16px;
+  padding: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.radar-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--app-primary);
+  margin: 0 0 1rem 0;
+}
+
+.radar-icon {
+  font-size: 1.4rem;
+  background: var(--app-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.radar-svg {
+  width: 100%;
+  max-width: 360px;
+  display: block;
+  margin: 0 auto;
+}
+
+/* Grid */
+.grid-ring {
+  fill: none;
+  stroke: var(--app-border);
+  stroke-width: 1;
+}
+
+.grid-ring.ring-max {
+  stroke: var(--app-primary);
+  stroke-opacity: 0.3;
+}
+
+/* Axes */
+.axis-line {
+  stroke: var(--app-border);
+  stroke-width: 1;
+}
+
+/* Data */
+.data-polygon {
+  fill: url(#radarGrad);
+  stroke: var(--app-primary);
+  stroke-width: 2;
+  stroke-linejoin: round;
+}
+
+.data-point {
+  fill: var(--app-primary);
+  stroke: white;
+  stroke-width: 1.5;
+}
+
+/* Labels */
+.axis-label {
+  font-size: 10px;
+  font-weight: 600;
+  fill: var(--app-text-body);
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+
+.axis-label.anchor-start {
+  text-anchor: start;
+}
+
+.axis-label.anchor-end {
+  text-anchor: end;
+}
+
+.stat-value-label {
+  font-size: 11px;
+  font-weight: 700;
+  fill: var(--app-primary);
+  text-anchor: middle;
+  dominant-baseline: middle;
+}
+
+.stat-value-label.anchor-start {
+  text-anchor: start;
+}
+
+.stat-value-label.anchor-end {
+  text-anchor: end;
+}

--- a/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.html
+++ b/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.html
@@ -1,0 +1,64 @@
+<div class="radar-card">
+  <h3 class="radar-title">
+    <span class="radar-icon">⬡</span>
+    Estadísticas de poder
+  </h3>
+
+  <svg class="radar-svg" viewBox="0 0 360 330" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <linearGradient id="radarGrad" x1="0%" y1="0%" x2="100%" y2="100%">
+        <stop offset="0%" style="stop-color:#4f46e5;stop-opacity:0.5" />
+        <stop offset="100%" style="stop-color:#9333ea;stop-opacity:0.5" />
+      </linearGradient>
+    </defs>
+
+    <!-- Grid rings -->
+    @for (ring of rings; track ring) {
+      <polygon
+        [attr.points]="gridPolygon(ring)"
+        class="grid-ring"
+        [class.ring-max]="ring === 100"
+      />
+    }
+
+    <!-- Axis lines -->
+    @for (ax of axes; track ax.key) {
+      <line
+        [attr.x1]="cx" [attr.y1]="cy"
+        [attr.x2]="axisEnd(ax.angle).x" [attr.y2]="axisEnd(ax.angle).y"
+        class="axis-line"
+      />
+    }
+
+    <!-- Data polygon -->
+    <polygon [attr.points]="statPolygon()" class="data-polygon" />
+
+    <!-- Data points -->
+    @for (ax of axes; track ax.key) {
+      <circle
+        [attr.cx]="axisEnd(ax.angle).x * (statValue(ax.key) / 100) + cx * (1 - statValue(ax.key) / 100)"
+        [attr.cy]="axisEnd(ax.angle).y * (statValue(ax.key) / 100) + cy * (1 - statValue(ax.key) / 100)"
+        r="4"
+        class="data-point"
+      />
+    }
+
+    <!-- Labels -->
+    @for (ax of axes; track ax.key) {
+      <text
+        [attr.x]="labelPos(ax.angle).x"
+        [attr.y]="labelPos(ax.angle).y"
+        class="axis-label"
+        [class.anchor-start]="labelPos(ax.angle).x > cx + 10"
+        [class.anchor-end]="labelPos(ax.angle).x < cx - 10"
+      >{{ ax.label }}</text>
+      <text
+        [attr.x]="labelPos(ax.angle).x"
+        [attr.y]="labelPos(ax.angle).y + 14"
+        class="stat-value-label"
+        [class.anchor-start]="labelPos(ax.angle).x > cx + 10"
+        [class.anchor-end]="labelPos(ax.angle).x < cx - 10"
+      >{{ statValue(ax.key) }}</text>
+    }
+  </svg>
+</div>

--- a/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.ts
+++ b/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.ts
@@ -1,0 +1,75 @@
+import { Component, computed, input } from '@angular/core';
+import { DEFAULT_POWER_STATS, IPowerStats } from '../../../../core/models/interfaces/hero.interface';
+
+interface RadarStat {
+  label: string;
+  key: keyof IPowerStats;
+  angle: number;
+}
+
+const STATS: RadarStat[] = [
+  { label: 'Inteligencia', key: 'intelligence', angle: 0 },
+  { label: 'Poder',        key: 'power',        angle: 60 },
+  { label: 'Velocidad',    key: 'speed',        angle: 120 },
+  { label: 'Durabilidad',  key: 'durability',   angle: 180 },
+  { label: 'Combate',      key: 'combat',       angle: 240 },
+  { label: 'Fuerza',       key: 'strength',     angle: 300 },
+];
+
+const R = 110;
+const CX = 180;
+const CY = 165;
+
+function toRad(deg: number): number {
+  return ((deg - 90) * Math.PI) / 180;
+}
+
+function point(angle: number, r: number): string {
+  const rad = toRad(angle);
+  return `${CX + r * Math.cos(rad)},${CY + r * Math.sin(rad)}`;
+}
+
+function pointObj(angle: number, r: number): { x: number; y: number } {
+  const rad = toRad(angle);
+  return { x: CX + r * Math.cos(rad), y: CY + r * Math.sin(rad) };
+}
+
+function polygon(values: number[]): string {
+  return values.map((v, i) => point(STATS[i].angle, (v / 100) * R)).join(' ');
+}
+
+@Component({
+  selector: 'app-hero-radar-chart',
+  templateUrl: './hero-radar-chart.component.html',
+  styleUrl: './hero-radar-chart.component.css',
+})
+export class HeroRadarChartComponent {
+  stats = input<IPowerStats>(DEFAULT_POWER_STATS);
+
+  readonly axes = STATS;
+  readonly rings = [25, 50, 75, 100];
+  readonly cx = CX;
+  readonly cy = CY;
+  readonly r = R;
+
+  gridPolygon(pct: number): string {
+    return polygon(Array(6).fill(pct));
+  }
+
+  statPolygon = computed(() => {
+    const s = this.stats();
+    return polygon(STATS.map((ax) => s[ax.key]));
+  });
+
+  axisEnd(angle: number): { x: number; y: number } {
+    return pointObj(angle, R);
+  }
+
+  labelPos(angle: number): { x: number; y: number } {
+    return pointObj(angle, R + 24);
+  }
+
+  statValue(key: keyof IPowerStats): number {
+    return this.stats()[key];
+  }
+}

--- a/src/app/features/heroes/pages/hero-detail/hero-detail.component.html
+++ b/src/app/features/heroes/pages/hero-detail/hero-detail.component.html
@@ -33,6 +33,9 @@
     </div>
   } @else if (hero(); as heroData) {
     <app-hero-info-cards [hero]="heroData" />
+    @if (heroData.powerStats) {
+      <app-hero-radar-chart [stats]="heroData.powerStats" />
+    }
     <app-hero-biography [description]="heroData.description" />
     <app-hero-stats [characters]="heroData.characters" [originators]="heroData.originators" />
     <app-hero-comic-section [firstAppearance]="heroData.firstAppearance" />

--- a/src/app/features/heroes/pages/hero-detail/hero-detail.component.ts
+++ b/src/app/features/heroes/pages/hero-detail/hero-detail.component.ts
@@ -3,6 +3,7 @@ import { HeroBiographyComponent } from '../../components/hero-biography/hero-bio
 import { HeroComicSectionComponent } from '../../components/hero-comic-section/hero-comic-section.component';
 import { HeroStatsComponent } from '../../components/hero-stats/hero-stats.component';
 import { HeroInfoCardsComponent } from '../../components/hero-info-cards/hero-info-cards.component';
+import { HeroRadarChartComponent } from '../../components/hero-radar-chart/hero-radar-chart.component';
 import { Router, RouterModule } from '@angular/router';
 import { HeroesService } from '../../services/heroes/heroes.service';
 import { rxResource } from '@angular/core/rxjs-interop';
@@ -17,6 +18,7 @@ import { MatDialog } from '@angular/material/dialog';
     HeroComicSectionComponent,
     HeroStatsComponent,
     HeroInfoCardsComponent,
+    HeroRadarChartComponent,
     MatIcon,
     MatButtonModule,
     RouterModule,

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.css
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.css
@@ -91,3 +91,75 @@
   color: var(--app-error);
   padding-left: 1rem;
 }
+
+/* Power Stats */
+.stats-section {
+  background: var(--app-surface-alt);
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  padding: 1.25rem 1.5rem;
+}
+
+.stats-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 1rem;
+  font-weight: 700;
+  color: var(--app-primary);
+  margin: 0 0 1.25rem 0;
+}
+
+.stats-title mat-icon {
+  color: var(--app-primary);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 2rem;
+}
+
+.stat-row {
+  display: flex;
+  flex-direction: column;
+}
+
+.stat-header {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  margin-bottom: 0.1rem;
+}
+
+.stat-icon {
+  font-size: 1rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--app-primary);
+}
+
+.stat-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--app-text-body);
+  flex: 1;
+}
+
+.stat-value {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--app-primary);
+  min-width: 2rem;
+  text-align: right;
+}
+
+.stat-slider {
+  width: 100%;
+}
+
+@media (max-width: 600px) {
+  .stats-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.html
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.html
@@ -110,6 +110,31 @@
       <input matInput formControlName="imgFa" type="url" />
     </mat-form-field>
 
+    <!-- Power Stats -->
+    <div class="stats-section">
+      <h3 class="stats-title">
+        <mat-icon>radar</mat-icon>
+        Estadísticas de poder
+      </h3>
+      <div class="stats-grid">
+        @for (stat of statLabels; track stat.key) {
+          <div class="stat-row">
+            <div class="stat-header">
+              <mat-icon class="stat-icon">{{ stat.icon }}</mat-icon>
+              <span class="stat-label">{{ stat.label }}</span>
+              <span class="stat-value">{{ powerStats[stat.key] }}</span>
+            </div>
+            <mat-slider min="0" max="100" step="1" class="stat-slider">
+              <input matSliderThumb
+                [value]="powerStats[stat.key]"
+                (valueChange)="powerStats[stat.key] = $event"
+              />
+            </mat-slider>
+          </div>
+        }
+      </div>
+    </div>
+
     <!-- Submit -->
     <div class="form-actions">
       <button mat-stroked-button type="button" routerLink="/heroes/list">Cancelar</button>

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.ts
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.ts
@@ -14,8 +14,9 @@ import { MatSelectModule } from '@angular/material/select';
 import { MatChipInputEvent, MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
+import { MatSliderModule } from '@angular/material/slider';
 import { HeroModel } from '../../../../core/models/class/hero.class';
-import { IHero } from '../../../../core/models/interfaces/hero.interface';
+import { DEFAULT_POWER_STATS, IHero, IPowerStats } from '../../../../core/models/interfaces/hero.interface';
 
 @Component({
   selector: 'app-hero-form',
@@ -26,6 +27,7 @@ import { IHero } from '../../../../core/models/interfaces/hero.interface';
     MatIconModule,
     MatInputModule,
     MatSelectModule,
+    MatSliderModule,
     ReactiveFormsModule,
     RouterModule,
   ],
@@ -35,6 +37,17 @@ import { IHero } from '../../../../core/models/interfaces/hero.interface';
 export class HeroFormComponent implements OnInit {
   readonly charactersKeywords = signal<string[]>([]);
   readonly originatorsKeywords = signal<string[]>([]);
+
+  powerStats: IPowerStats = { ...DEFAULT_POWER_STATS };
+
+  readonly statLabels: { key: keyof IPowerStats; label: string; icon: string }[] = [
+    { key: 'intelligence', label: 'Inteligencia', icon: 'psychology' },
+    { key: 'strength',     label: 'Fuerza',       icon: 'fitness_center' },
+    { key: 'speed',        label: 'Velocidad',    icon: 'speed' },
+    { key: 'durability',   label: 'Durabilidad',  icon: 'shield' },
+    { key: 'combat',       label: 'Combate',      icon: 'sports_martial_arts' },
+    { key: 'power',        label: 'Poder',        icon: 'bolt' },
+  ];
 
   heroForm: FormGroup;
 
@@ -81,6 +94,9 @@ export class HeroFormComponent implements OnInit {
           });
           this.charactersKeywords.set(hero.characters);
           this.originatorsKeywords.set(hero.originators);
+          if (hero.powerStats) {
+            this.powerStats = { ...hero.powerStats };
+          }
         }
       });
     }
@@ -102,6 +118,7 @@ export class HeroFormComponent implements OnInit {
         key: id,
         characters: this.charactersKeywords(),
         originators: this.originatorsKeywords(),
+        powerStats: { ...this.powerStats },
       });
       this.save(hero);
     }


### PR DESCRIPTION
## Summary
- Add IPowerStats interface (strength, speed, intelligence, durability, combat, power) to hero model
- Seed all 18 mock heroes with realistic power stat values
- New HeroRadarChartComponent: pure SVG hexagonal spider chart in hero-detail
- Add comfortable slider inputs (0-100) in hero-form for all 6 stats

## Test plan
- [ ] Open any hero detail page -> radar chart renders with correct shape
- [ ] Create a new hero -> sliders default to 50 for all stats
- [ ] Edit an existing hero -> sliders load the hero current stats
- [ ] Submit form -> powerStats saved and reflected in the radar chart

Generated with Claude Code