### PR TITLE
feat(ux): navigation improvements — scroll, URL filters, breadcrumbs

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,7 +5,7 @@ import {
   provideBrowserGlobalErrorListeners,
   provideZonelessChangeDetection,
 } from '@angular/core';
-import { provideRouter, withComponentInputBinding } from '@angular/router';
+import { provideRouter, withComponentInputBinding, withInMemoryScrolling } from '@angular/router';
 
 import { routes } from './app.routes';
 import {
@@ -18,7 +18,11 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideBrowserGlobalErrorListeners(),
     provideZonelessChangeDetection(),
-    provideRouter(routes, withComponentInputBinding()),
+    provideRouter(
+      routes,
+      withComponentInputBinding(),
+      withInMemoryScrolling({ scrollPositionRestoration: 'enabled', anchorScrolling: 'enabled' }),
+    ),
     provideHttpClient(withInterceptorsFromDi()),
     provideAppInitializer(() => {
       const initDb = inject(InitDbService);

--- a/src/app/features/heroes/components/hero-info-cards/hero-info-cards.component.html
+++ b/src/app/features/heroes/components/hero-info-cards/hero-info-cards.component.html
@@ -53,38 +53,6 @@
         </div>
       </div>
 
-      <!-- Card: Creadores -->
-      <div class="info-card">
-        <div class="card-icon">
-          <mat-icon>brush</mat-icon>
-        </div>
-        <div class="card-content">
-          <span class="card-label">Creadores</span>
-          <span class="card-value">{{ hero().originators.join(", ") }}</span>
-        </div>
-      </div>
-
-      <!-- Card: Primera Aparición -->
-      <div class="info-card">
-        <div class="card-icon">
-          <mat-icon>auto_stories</mat-icon>
-        </div>
-        <div class="card-content">
-          <span class="card-label">Primera aparición</span>
-          <span class="card-value">{{ hero().firstAppearance }}</span>
-        </div>
-      </div>
-
-      <!-- Card: Personajes -->
-      <div class="info-card">
-        <div class="card-icon">
-          <mat-icon>groups</mat-icon>
-        </div>
-        <div class="card-content">
-          <span class="card-label">Personajes</span>
-          <span class="card-value">{{ hero().characters.join(", ") }}</span>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/src/app/features/heroes/components/hero-stats/hero-stats.component.css
+++ b/src/app/features/heroes/components/hero-stats/hero-stats.component.css
@@ -31,3 +31,107 @@ mat-chip-set {
   flex-wrap: wrap;
   gap: 0.5rem;
 }
+
+/* Creator chips with Wikipedia popover */
+.creator-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.creator-chip-wrapper {
+  position: relative;
+  display: inline-flex;
+}
+
+.creator-chip {
+  cursor: pointer;
+  transition: background 0.15s ease;
+}
+
+.wiki-popover {
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 0;
+  z-index: 100;
+  width: 320px;
+  background: white;
+  border: 1px solid var(--app-border);
+  border-radius: 12px;
+  box-shadow: 0 8px 24px rgba(79, 70, 229, 0.15);
+  overflow: hidden;
+  animation: popover-in 0.15s ease;
+}
+
+@keyframes popover-in {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+.wiki-loading,
+.wiki-error {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 1rem;
+  font-size: 0.875rem;
+  color: var(--app-text-muted);
+}
+
+.wiki-content {
+  display: flex;
+  flex-direction: row;
+  gap: 0;
+}
+
+.wiki-thumb {
+  width: 110px;
+  min-height: 160px;
+  flex-shrink: 0;
+  object-fit: cover;
+  border-radius: 0;
+}
+
+.wiki-text {
+  padding: 0.75rem 1rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.wiki-title {
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--app-primary);
+  margin: 0;
+}
+
+.wiki-extract {
+  font-size: 0.8rem;
+  color: var(--app-text-body);
+  line-height: 1.5;
+  margin: 0;
+  display: -webkit-box;
+  -webkit-line-clamp: 4;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.wiki-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  font-weight: 600;
+  color: var(--app-primary);
+  text-decoration: none;
+  margin-top: 0.25rem;
+}
+
+.wiki-link mat-icon {
+  font-size: 0.9rem;
+  width: 0.9rem;
+  height: 0.9rem;
+}

--- a/src/app/features/heroes/components/hero-stats/hero-stats.component.html
+++ b/src/app/features/heroes/components/hero-stats/hero-stats.component.html
@@ -2,8 +2,8 @@
   @if (characters().length > 0) {
     <div class="stat-group">
       <h3 class="section-title">
-        <mat-icon>groups</mat-icon>
-        Personajes asociados
+        <mat-icon>masks</mat-icon>
+        Alter Egos
       </h3>
       <mat-chip-set>
         @for (character of characters(); track character) {
@@ -19,11 +19,55 @@
         <mat-icon>brush</mat-icon>
         Creadores
       </h3>
-      <mat-chip-set>
+      <div class="creator-chips">
         @for (originator of originators(); track originator) {
-          <mat-chip>{{ originator }}</mat-chip>
+          <div
+            class="creator-chip-wrapper"
+            (mouseenter)="onCreatorHover(originator)"
+            (mouseleave)="onCreatorLeave()"
+          >
+            <mat-chip class="creator-chip">{{ originator }}</mat-chip>
+            @if (hoveredCreator() === originator) {
+              <div class="wiki-popover">
+                @if (wikiLoading()) {
+                  <div class="wiki-loading">
+                    <mat-icon>hourglass_empty</mat-icon>
+                    <span>Cargando...</span>
+                  </div>
+                } @else if (wikiError()) {
+                  <div class="wiki-error">
+                    <mat-icon>info_outline</mat-icon>
+                    <span>No encontrado en Wikipedia</span>
+                  </div>
+                } @else if (wikiData()) {
+                  <div class="wiki-content">
+                    @if (wikiData()!.thumbnail) {
+                      <img
+                        [src]="wikiData()!.thumbnail!.source"
+                        [alt]="wikiData()!.title"
+                        class="wiki-thumb"
+                      />
+                    }
+                    <div class="wiki-text">
+                      <p class="wiki-title">{{ wikiData()!.title }}</p>
+                      <p class="wiki-extract">{{ wikiData()!.extract }}</p>
+                      <a
+                        [href]="wikiData()!.content_urls?.desktop?.page"
+                        target="_blank"
+                        rel="noopener"
+                        class="wiki-link"
+                      >
+                        <mat-icon>open_in_new</mat-icon>
+                        Ver en Wikipedia
+                      </a>
+                    </div>
+                  </div>
+                }
+              </div>
+            }
+          </div>
         }
-      </mat-chip-set>
+      </div>
     </div>
   }
 </section>

--- a/src/app/features/heroes/components/hero-stats/hero-stats.component.ts
+++ b/src/app/features/heroes/components/hero-stats/hero-stats.component.ts
@@ -1,6 +1,13 @@
-import { Component, input } from '@angular/core';
+import { Component, input, signal } from '@angular/core';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
+
+interface WikiSummary {
+  title: string;
+  extract: string;
+  thumbnail?: { source: string };
+  content_urls?: { desktop: { page: string } };
+}
 
 @Component({
   selector: 'app-hero-stats',
@@ -11,4 +18,46 @@ import { MatChipsModule } from '@angular/material/chips';
 export class HeroStatsComponent {
   characters = input.required<string[]>();
   originators = input.required<string[]>();
+
+  hoveredCreator = signal<string | null>(null);
+  wikiData = signal<WikiSummary | null>(null);
+  wikiLoading = signal(false);
+  wikiError = signal(false);
+
+  async onCreatorHover(name: string): Promise<void> {
+    this.hoveredCreator.set(name);
+    this.wikiData.set(null);
+    this.wikiLoading.set(true);
+    this.wikiError.set(false);
+    try {
+      const encoded = encodeURIComponent(name.replace(/ /g, '_'));
+      const res = await fetch(`https://en.wikipedia.org/api/rest_v1/page/summary/${encoded}`);
+      if (!res.ok) throw new Error();
+      const data: WikiSummary = await res.json();
+      if (this.hoveredCreator() !== name) return;
+      const normalize = (s: string) => s.toLowerCase().trim();
+      const matched =
+        normalize(data.title).includes(normalize(name)) ||
+        normalize(name).includes(normalize(data.title));
+      if (matched) {
+        this.wikiData.set(data);
+      } else {
+        this.wikiError.set(true);
+      }
+    } catch {
+      if (this.hoveredCreator() === name) {
+        this.wikiError.set(true);
+      }
+    } finally {
+      if (this.hoveredCreator() === name) {
+        this.wikiLoading.set(false);
+      }
+    }
+  }
+
+  onCreatorLeave(): void {
+    this.hoveredCreator.set(null);
+    this.wikiData.set(null);
+    this.wikiError.set(false);
+  }
 }

--- a/src/app/features/heroes/pages/hero-detail/hero-detail.component.html
+++ b/src/app/features/heroes/pages/hero-detail/hero-detail.component.html
@@ -1,5 +1,7 @@
 <div class="hero-detail-container">
 
+  <app-breadcrumb [items]="breadcrumb()" />
+
   <!-- Barra de acciones superior -->
   <div class="detail-toolbar">
     <button mat-icon-button (click)="goBack()" aria-label="Volver al listado">
@@ -33,10 +35,10 @@
     </div>
   } @else if (hero(); as heroData) {
     <app-hero-info-cards [hero]="heroData" />
+    <app-hero-biography [description]="heroData.description" />
     @if (heroData.powerStats) {
       <app-hero-radar-chart [stats]="heroData.powerStats" />
     }
-    <app-hero-biography [description]="heroData.description" />
     <app-hero-stats [characters]="heroData.characters" [originators]="heroData.originators" />
     <app-hero-comic-section [firstAppearance]="heroData.firstAppearance" />
   }

--- a/src/app/features/heroes/pages/hero-detail/hero-detail.component.ts
+++ b/src/app/features/heroes/pages/hero-detail/hero-detail.component.ts
@@ -1,9 +1,11 @@
-import { Component, inject, input } from '@angular/core';
+import { Component, computed, inject, input } from '@angular/core';
 import { HeroBiographyComponent } from '../../components/hero-biography/hero-biography.component';
 import { HeroComicSectionComponent } from '../../components/hero-comic-section/hero-comic-section.component';
 import { HeroStatsComponent } from '../../components/hero-stats/hero-stats.component';
 import { HeroInfoCardsComponent } from '../../components/hero-info-cards/hero-info-cards.component';
 import { HeroRadarChartComponent } from '../../components/hero-radar-chart/hero-radar-chart.component';
+import { Location } from '@angular/common';
+import { BreadcrumbComponent } from '../../../../shared/ui/breadcrumb/breadcrumb.component';
 import { Router, RouterModule } from '@angular/router';
 import { HeroesService } from '../../services/heroes/heroes.service';
 import { rxResource } from '@angular/core/rxjs-interop';
@@ -19,6 +21,7 @@ import { MatDialog } from '@angular/material/dialog';
     HeroStatsComponent,
     HeroInfoCardsComponent,
     HeroRadarChartComponent,
+    BreadcrumbComponent,
     MatIcon,
     MatButtonModule,
     RouterModule,
@@ -28,6 +31,7 @@ import { MatDialog } from '@angular/material/dialog';
 })
 export default class HeroDetailComponent {
   private router = inject(Router);
+  private location = inject(Location);
   private heroesService = inject(HeroesService);
 
   id = input.required<string>();
@@ -40,8 +44,13 @@ export default class HeroDetailComponent {
   isLoading = this.heroResource.isLoading;
   error = this.heroResource.error;
 
+  breadcrumb = computed(() => [
+    { label: 'Héroes', route: '/heroes/list' },
+    { label: this.hero()?.superhero ?? '...' },
+  ]);
+
   goBack(): void {
-    this.router.navigate(['/heroes/list']);
+    this.location.back();
   }
 
   editHero(): void {

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.css
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.css
@@ -78,6 +78,7 @@
   gap: 0.25rem;
   transition: border-color 0.2s ease;
   background: var(--app-surface);
+  cursor: text;
 }
 
 .chip-wrapper:focus-within {

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.html
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.html
@@ -1,6 +1,7 @@
 <div class="form-page">
+  <app-breadcrumb [items]="breadcrumb" />
   <div class="form-header">
-    <button mat-icon-button routerLink="/heroes/list" type="button">
+    <button mat-icon-button (click)="goBack()" type="button">
       <mat-icon>arrow_back</mat-icon>
     </button>
     <h1 class="form-title">{{ editing ? 'Editar héroe' : 'Nuevo héroe' }}</h1>
@@ -49,9 +50,9 @@
 
     <!-- Characters -->
     <div class="chip-field">
-      <label class="chip-label">Personajes asociados</label>
-      <div class="chip-wrapper">
-        <mat-chip-grid #chipList aria-label="Personajes">
+      <label class="chip-label">Alter Egos</label>
+      <div class="chip-wrapper" (click)="charInput.focus()">
+        <mat-chip-grid #chipList aria-label="Alter Egos">
           @for (keyword of charactersKeywords(); track keyword) {
             <mat-chip (removed)="removeChip(keyword, 'character')">
               {{ keyword }}
@@ -59,7 +60,8 @@
             </mat-chip>
           }
           <input
-            placeholder="Añadir personaje y pulsar Enter..."
+            #charInput
+            placeholder="Añadir alter ego y pulsar Enter..."
             [matChipInputFor]="chipList"
             (matChipInputTokenEnd)="addChip($event, 'character')"
           />
@@ -70,7 +72,7 @@
     <!-- Originators -->
     <div class="chip-field">
       <label class="chip-label">Creadores <span class="required-mark">*</span></label>
-      <div class="chip-wrapper">
+      <div class="chip-wrapper" (click)="origInput.focus()">
         <mat-chip-grid #originatorsList aria-label="Creadores">
           @for (keyword of originatorsKeywords(); track keyword) {
             <mat-chip (removed)="removeChip(keyword, 'originator')">
@@ -79,6 +81,7 @@
             </mat-chip>
           }
           <input
+            #origInput
             placeholder="Añadir creador y pulsar Enter..."
             [matChipInputFor]="originatorsList"
             (matChipInputTokenEnd)="addChip($event, 'originator')"
@@ -137,7 +140,7 @@
 
     <!-- Submit -->
     <div class="form-actions">
-      <button mat-stroked-button type="button" routerLink="/heroes/list">Cancelar</button>
+      <button mat-stroked-button type="button" (click)="goBack()">Cancelar</button>
       <button mat-raised-button color="primary" type="submit" [disabled]="heroForm.invalid || originatorsKeywords().length === 0">
         <mat-icon>save</mat-icon>
         {{ editing ? 'Guardar cambios' : 'Crear héroe' }}

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.ts
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnInit, signal } from '@angular/core';
+import { BreadcrumbComponent, BreadcrumbItem } from '../../../../shared/ui/breadcrumb/breadcrumb.component';
 import {
   FormBuilder,
   FormGroup,
@@ -7,6 +8,7 @@ import {
 } from '@angular/forms';
 import { EPublisher } from '../../../../core/models/enums/publisher.enum';
 import { HeroesService } from '../../services/heroes/heroes.service';
+import { Location } from '@angular/common';
 import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
@@ -21,6 +23,7 @@ import { DEFAULT_POWER_STATS, IHero, IPowerStats } from '../../../../core/models
 @Component({
   selector: 'app-hero-form',
   imports: [
+    BreadcrumbComponent,
     MatButtonModule,
     MatChipsModule,
     MatFormFieldModule,
@@ -58,11 +61,13 @@ export class HeroFormComponent implements OnInit {
 
   editing = false;
   heroId: string | null = null;
+  breadcrumb: BreadcrumbItem[] = [{ label: 'Héroes', route: '/heroes/list' }, { label: 'Nuevo héroe' }];
 
   constructor(
     private fb: FormBuilder,
     private heroesService: HeroesService,
     private router: Router,
+    private location: Location,
     private route: ActivatedRoute,
   ) {
     this.heroForm = this.fb.group({
@@ -80,6 +85,7 @@ export class HeroFormComponent implements OnInit {
     this.heroId = this.route.snapshot.paramMap.get('id');
     if (this.heroId) {
       this.editing = true;
+      this.breadcrumb = [{ label: 'Héroes', route: '/heroes/list' }, { label: 'Editar héroe' }];
       this.heroesService.getHeroById(this.heroId).subscribe((hero) => {
         if (hero) {
           const publisherKey = Object.entries(EPublisher).find(([, val]) => val === hero.publisher)?.[0] ?? 'DC';
@@ -100,6 +106,10 @@ export class HeroFormComponent implements OnInit {
         }
       });
     }
+  }
+
+  goBack(): void {
+    this.location.back();
   }
 
   generateId(): string {

--- a/src/app/features/heroes/pages/heroes-list/heroes-list.component.ts
+++ b/src/app/features/heroes/pages/heroes-list/heroes-list.component.ts
@@ -1,4 +1,4 @@
-import { Component, computed, inject, OnInit, signal } from '@angular/core';
+import { Component, computed, effect, inject, signal } from '@angular/core';
 import { HeroesService } from '../../services/heroes/heroes.service';
 import { CardComponent } from '../../../../shared/ui/card/card.component';
 import { EPublisher } from '../../../../core/models/enums/publisher.enum';
@@ -12,7 +12,7 @@ import { MatFormFieldModule } from '@angular/material/form-field';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { IHeroFilters } from '../../../../core/models/interfaces/hero.interface';
-import { Router, RouterModule } from '@angular/router';
+import { ActivatedRoute, Router, RouterModule } from '@angular/router';
 
 @Component({
   selector: 'app-heroes-list',
@@ -35,6 +35,7 @@ import { Router, RouterModule } from '@angular/router';
 export default class HeroesListPageComponent {
   private heroesService = inject(HeroesService);
   private router = inject(Router);
+  private route = inject(ActivatedRoute);
 
   // Signals para filtros
   searchTerm = signal<string>('');
@@ -43,6 +44,33 @@ export default class HeroesListPageComponent {
   alterEgoFilter = signal<string>('');
   originatorFilter = signal<string>('');
   showAdvancedFilters = signal<boolean>(false);
+
+  constructor() {
+    // Inicializar filtros desde la URL
+    const params = this.route.snapshot.queryParams;
+    if (params['search']) this.searchTerm.set(params['search']);
+    if (params['publisher']) this.selectedPublisher.set(params['publisher'] as EPublisher);
+    if (params['name']) this.nameFilter.set(params['name']);
+    if (params['alterEgo']) this.alterEgoFilter.set(params['alterEgo']);
+    if (params['originator']) this.originatorFilter.set(params['originator']);
+    if (params['advanced'] === 'true') this.showAdvancedFilters.set(true);
+
+    // Sincronizar filtros a la URL sin añadir entradas al historial
+    effect(() => {
+      const f = this.filters();
+      this.router.navigate([], {
+        queryParams: {
+          search: f.searchTerm || null,
+          publisher: f.publisher || null,
+          name: f.superhero || null,
+          alterEgo: f.alterEgo || null,
+          originator: f.originator || null,
+          advanced: this.showAdvancedFilters() ? 'true' : null,
+        },
+        replaceUrl: true,
+      });
+    });
+  }
 
   // Publishers disponibles para el filtro
   publishers: EPublisher[] = Object.values(EPublisher);

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.css
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.css
@@ -1,0 +1,34 @@
+.breadcrumb {
+  display: flex;
+  align-items: center;
+  gap: 0.125rem;
+  margin-bottom: 1rem;
+}
+
+.breadcrumb-link {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--app-primary);
+  text-decoration: none;
+  opacity: 0.75;
+  transition: opacity 0.15s ease;
+}
+
+.breadcrumb-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
+
+.breadcrumb-current {
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: var(--app-text);
+}
+
+.breadcrumb-sep {
+  font-size: 1rem;
+  width: 1rem;
+  height: 1rem;
+  color: var(--app-text-muted);
+  opacity: 0.5;
+}

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.html
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.html
@@ -1,0 +1,12 @@
+<nav class="breadcrumb" aria-label="breadcrumb">
+  @for (item of items(); track item.label; let last = $last) {
+    @if (item.route && !last) {
+      <a [routerLink]="item.route" class="breadcrumb-link">{{ item.label }}</a>
+    } @else {
+      <span class="breadcrumb-current">{{ item.label }}</span>
+    }
+    @if (!last) {
+      <mat-icon class="breadcrumb-sep">chevron_right</mat-icon>
+    }
+  }
+</nav>

--- a/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/ui/breadcrumb/breadcrumb.component.ts
@@ -1,0 +1,18 @@
+import { Component, input } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { MatIconModule } from '@angular/material/icon';
+
+export interface BreadcrumbItem {
+  label: string;
+  route?: string;
+}
+
+@Component({
+  selector: 'app-breadcrumb',
+  imports: [RouterModule, MatIconModule],
+  templateUrl: './breadcrumb.component.html',
+  styleUrl: './breadcrumb.component.css',
+})
+export class BreadcrumbComponent {
+  items = input.required<BreadcrumbItem[]>();
+}


### PR DESCRIPTION
## Summary
- Scroll position restoration via `withInMemoryScrolling` in app.config
- Heroes list filters synced to URL query params (`?search=bat&publisher=Marvel`)
- `Location.back()` in hero-detail and hero-form (preserves filter state on back)
- New `BreadcrumbComponent` in `shared/ui/breadcrumb/`
- Hero-detail section reorder: info → biography → radar → alter egos → creators → first appearance
- Rename Personajes asociados → Alter Egos
- Wikipedia popover (photo + summary) on creator chips
- Fix chip-wrapper click area in hero-form

## Test plan
- [ ] Apply filters, navigate to hero and back → filters still active in URL and UI
- [ ] Scroll down list, open hero and go back → scroll position restored
- [ ] Check breadcrumb shows correct path in detail and form
- [ ] Hover a creator chip → Wikipedia popover appears with photo and summary

Generated with Claude Code