### PR TITLE
test(#12): add unit tests — 91/91 passing, 70% coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "heroes",
       "version": "0.0.0",
       "dependencies": {
+        "@angular/animations": "^20.3.17",
         "@angular/cdk": "^20.2.12",
         "@angular/common": "^20.0.0",
         "@angular/compiler": "^20.0.0",
@@ -348,6 +349,21 @@
         "chokidar": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular/animations": {
+      "version": "20.3.17",
+      "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-20.3.17.tgz",
+      "integrity": "sha512-KvdgFjCTkOD3WVt4gzmJOoX914eey/Efu2Pb/KUM0Bqp1ZoXiFpI48GCd1b6Ks8JlDBeAfgjtpdSUB2aLnMRZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@angular/core": "20.3.17"
       }
     },
     "node_modules/@angular/build": {
@@ -5411,17 +5427,6 @@
       },
       "engines": {
         "node": ">= 0.4"
-      }
-    },
-    "node_modules/hono": {
-      "version": "4.11.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.5.tgz",
-      "integrity": "sha512-WemPi9/WfyMwZs+ZUXdiwcCh9Y+m7L+8vki9MzDw3jJ+W9Lc+12HGsd368Qc1vZi1xwW8BWMMsnK5efYKPdt4g==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=16.9.0"
       }
     },
     "node_modules/hosted-git-info": {

--- a/package.json
+++ b/package.json
@@ -6,10 +6,12 @@
     "start": "ng serve",
     "build": "ng build",
     "watch": "ng build --watch --configuration development",
-    "test": "ng test"
+    "test": "ng test",
+    "test:coverage": "ng test --code-coverage --watch=false --browsers=ChromeHeadless"
   },
   "private": true,
   "dependencies": {
+    "@angular/animations": "^20.3.17",
     "@angular/cdk": "^20.2.12",
     "@angular/common": "^20.0.0",
     "@angular/compiler": "^20.0.0",

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,25 +1,39 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { HeroesService } from './features/heroes/services/heroes/heroes.service';
+import { of } from 'rxjs';
 import { App } from './app';
 
 describe('App', () => {
+  let mockHeroesService: jasmine.SpyObj<HeroesService>;
+
   beforeEach(async () => {
+    mockHeroesService = jasmine.createSpyObj('HeroesService', ['getAll', 'getFilteredHeroCards']);
+    mockHeroesService.getAll.and.returnValue(of([]));
+    mockHeroesService.getFilteredHeroCards.and.returnValue(of([]));
+
     await TestBed.configureTestingModule({
       imports: [App],
-      providers: [provideZonelessChangeDetection()]
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: HeroesService, useValue: mockHeroesService },
+      ],
     }).compileComponents();
   });
 
   it('should create the app', () => {
     const fixture = TestBed.createComponent(App);
-    const app = fixture.componentInstance;
-    expect(app).toBeTruthy();
+    expect(fixture.componentInstance).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should contain a router-outlet', () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, heroes');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/src/app/core/models/class/hero.class.spec.ts
+++ b/src/app/core/models/class/hero.class.spec.ts
@@ -1,0 +1,84 @@
+import { HeroModel } from './hero.class';
+import { EPublisher } from '../enums/publisher.enum';
+import { DEFAULT_POWER_STATS } from '../interfaces/hero.interface';
+
+const BASE_HERO = {
+  id: 'dc-batman',
+  key: 'dc-batman',
+  superhero: 'Batman',
+  publisher: EPublisher.DC,
+  alterEgo: 'Bruce Wayne',
+  firstAppearance: 'Detective Comics #27',
+  characters: ['Bruce Wayne'],
+  originators: ['Bob Kane', 'Bill Finger'],
+  description: 'Dark Knight of Gotham',
+};
+
+describe('HeroModel', () => {
+  describe('constructor with no data', () => {
+    it('should set empty strings for text fields', () => {
+      const hero = new HeroModel();
+      expect(hero.id).toBe('');
+      expect(hero.key).toBe('');
+      expect(hero.superhero).toBe('');
+      expect(hero.alterEgo).toBe('');
+      expect(hero.firstAppearance).toBe('');
+      expect(hero.description).toBe('');
+    });
+
+    it('should default publisher to DC', () => {
+      expect(new HeroModel().publisher).toBe(EPublisher.DC);
+    });
+
+    it('should default arrays to empty', () => {
+      const hero = new HeroModel();
+      expect(hero.characters).toEqual([]);
+      expect(hero.originators).toEqual([]);
+    });
+
+    it('should default powerStats to DEFAULT_POWER_STATS', () => {
+      expect(new HeroModel().powerStats).toEqual(DEFAULT_POWER_STATS);
+    });
+
+    it('should leave fileManager undefined', () => {
+      expect(new HeroModel().fileManager).toBeUndefined();
+    });
+  });
+
+  describe('constructor with full data', () => {
+    it('should map all text fields correctly', () => {
+      const hero = new HeroModel(BASE_HERO);
+      expect(hero.id).toBe('dc-batman');
+      expect(hero.key).toBe('dc-batman');
+      expect(hero.superhero).toBe('Batman');
+      expect(hero.alterEgo).toBe('Bruce Wayne');
+      expect(hero.firstAppearance).toBe('Detective Comics #27');
+      expect(hero.description).toBe('Dark Knight of Gotham');
+    });
+
+    it('should set publisher correctly', () => {
+      expect(new HeroModel(BASE_HERO).publisher).toBe(EPublisher.DC);
+    });
+
+    it('should set arrays correctly', () => {
+      const hero = new HeroModel(BASE_HERO);
+      expect(hero.characters).toEqual(['Bruce Wayne']);
+      expect(hero.originators).toEqual(['Bob Kane', 'Bill Finger']);
+    });
+
+    it('should use DEFAULT_POWER_STATS when powerStats not provided', () => {
+      expect(new HeroModel(BASE_HERO).powerStats).toEqual(DEFAULT_POWER_STATS);
+    });
+
+    it('should use provided powerStats', () => {
+      const stats = { strength: 100, speed: 90, intelligence: 80, durability: 70, combat: 60, power: 50 };
+      const hero = new HeroModel({ ...BASE_HERO, powerStats: stats });
+      expect(hero.powerStats).toEqual(stats);
+    });
+
+    it('should set fileManager when provided', () => {
+      const fm = { imgBg: 'bg.jpg', imgHero: 'hero.jpg', imgFA: 'fa.jpg' };
+      expect(new HeroModel({ ...BASE_HERO, fileManager: fm }).fileManager).toEqual(fm);
+    });
+  });
+});

--- a/src/app/core/services/init-db/init-db.service.spec.ts
+++ b/src/app/core/services/init-db/init-db.service.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { InitDbService } from './init-db.service';
@@ -6,7 +7,8 @@ describe('InitDbService', () => {
   let service: InitDbService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],});
     service = TestBed.inject(InitDbService);
   });
 

--- a/src/app/features/about/about.component.spec.ts
+++ b/src/app/features/about/about.component.spec.ts
@@ -1,4 +1,8 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { of } from 'rxjs';
+import { HeroesService } from '../heroes/services/heroes/heroes.service';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { AboutComponent } from './about.component';
 
@@ -8,6 +12,7 @@ describe('AboutComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection(), provideRouter([]), { provide: HeroesService, useValue: { getAll: () => of([]) } }],
       imports: [AboutComponent]
     })
     .compileComponents();

--- a/src/app/features/heroes/components/hero-3d-viewer/hero-3d-viewer.component.spec.ts
+++ b/src/app/features/heroes/components/hero-3d-viewer/hero-3d-viewer.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { Hero3dViewerComponent } from './hero-3d-viewer.component';
@@ -8,6 +9,7 @@ describe('Hero3dViewerComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
       imports: [Hero3dViewerComponent],
     }).compileComponents();
 

--- a/src/app/features/heroes/components/hero-biography/hero-biography.component.spec.ts
+++ b/src/app/features/heroes/components/hero-biography/hero-biography.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeroBiographyComponent } from './hero-biography.component';
@@ -8,12 +9,14 @@ describe('HeroBiographyComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
       imports: [HeroBiographyComponent]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(HeroBiographyComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput("description", "Dark Knight of Gotham");
     fixture.detectChanges();
   });
 

--- a/src/app/features/heroes/components/hero-comic-section/hero-comic-section.component.spec.ts
+++ b/src/app/features/heroes/components/hero-comic-section/hero-comic-section.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeroComicSectionComponent } from './hero-comic-section.component';
@@ -8,12 +9,14 @@ describe('HeroComicSectionComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
       imports: [HeroComicSectionComponent]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(HeroComicSectionComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput("firstAppearance", "Detective Comics #27");
     fixture.detectChanges();
   });
 

--- a/src/app/features/heroes/components/hero-info-cards/hero-info-cards.component.spec.ts
+++ b/src/app/features/heroes/components/hero-info-cards/hero-info-cards.component.spec.ts
@@ -1,3 +1,7 @@
+import { EPublisher } from '../../../../core/models/enums/publisher.enum';
+import { DEFAULT_POWER_STATS } from '../../../../core/models/interfaces/hero.interface';
+const MOCK = { id: "dc-batman", key: "dc-batman", superhero: "Batman", publisher: EPublisher.DC, alterEgo: "Bruce Wayne", firstAppearance: "Detective Comics #27", characters: [], originators: ["Bob Kane"], description: "", powerStats: DEFAULT_POWER_STATS };
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeroInfoCardsComponent } from './hero-info-cards.component';
@@ -8,12 +12,14 @@ describe('HeroInfoCardsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
       imports: [HeroInfoCardsComponent]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(HeroInfoCardsComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput("hero", MOCK);
     fixture.detectChanges();
   });
 

--- a/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.spec.ts
+++ b/src/app/features/heroes/components/hero-radar-chart/hero-radar-chart.component.spec.ts
@@ -1,0 +1,102 @@
+import { provideZonelessChangeDetection } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { HeroRadarChartComponent } from './hero-radar-chart.component';
+import { DEFAULT_POWER_STATS, IPowerStats } from '../../../../core/models/interfaces/hero.interface';
+
+const MAX_STATS: IPowerStats = { strength: 100, speed: 100, intelligence: 100, durability: 100, combat: 100, power: 100 };
+const MIN_STATS: IPowerStats = { strength: 0, speed: 0, intelligence: 0, durability: 0, combat: 0, power: 0 };
+
+describe('HeroRadarChartComponent', () => {
+  let fixture: ComponentFixture<HeroRadarChartComponent>;
+  let component: HeroRadarChartComponent;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HeroRadarChartComponent],
+      providers: [provideZonelessChangeDetection()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeroRadarChartComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('stats', DEFAULT_POWER_STATS);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('gridPolygon()', () => {
+    it('should return a string with 6 space-separated points', () => {
+      const points = component.gridPolygon(100).trim().split(' ');
+      expect(points.length).toBe(6);
+    });
+
+    it('each point should be in "x,y" format', () => {
+      component.gridPolygon(50).trim().split(' ').forEach(pt => {
+        const parts = pt.split(',');
+        expect(parts.length).toBe(2);
+        expect(isNaN(Number(parts[0]))).toBeFalse();
+        expect(isNaN(Number(parts[1]))).toBeFalse();
+      });
+    });
+
+    it('100% ring should be larger than 50% ring', () => {
+      const ring100 = component.gridPolygon(100).trim().split(' ')[0];
+      const ring50 = component.gridPolygon(50).trim().split(' ')[0];
+      const x100 = Number(ring100.split(',')[0]);
+      const x50 = Number(ring50.split(',')[0]);
+      expect(Math.abs(x100)).toBeGreaterThan(Math.abs(x50 - component.cx) ? Math.abs(x50 - component.cx) : 0);
+    });
+  });
+
+  describe('statPolygon()', () => {
+    it('should return a string with 6 space-separated points', () => {
+      const points = component.statPolygon().trim().split(' ');
+      expect(points.length).toBe(6);
+    });
+
+    it('should produce different polygon for different stats', () => {
+      fixture.componentRef.setInput('stats', MAX_STATS);
+      fixture.detectChanges();
+      const maxPolygon = component.statPolygon();
+
+      fixture.componentRef.setInput('stats', MIN_STATS);
+      fixture.detectChanges();
+      const minPolygon = component.statPolygon();
+
+      expect(maxPolygon).not.toBe(minPolygon);
+    });
+
+    it('should be reactive to stats input changes', () => {
+      const before = component.statPolygon();
+      fixture.componentRef.setInput('stats', { ...DEFAULT_POWER_STATS, strength: 100 });
+      fixture.detectChanges();
+      expect(component.statPolygon()).not.toBe(before);
+    });
+  });
+
+  describe('axisEnd()', () => {
+    it('should return an object with x and y numbers', () => {
+      const pt = component.axisEnd(0);
+      expect(typeof pt.x).toBe('number');
+      expect(typeof pt.y).toBe('number');
+    });
+
+    it('top axis (0°) should have x close to cx and y less than cy', () => {
+      const pt = component.axisEnd(0);
+      expect(Math.abs(pt.x - component.cx)).toBeLessThan(1);
+      expect(pt.y).toBeLessThan(component.cy);
+    });
+  });
+
+  describe('labelPos()', () => {
+    it('should return position further from center than axisEnd', () => {
+      const axis = component.axisEnd(0);
+      const label = component.labelPos(0);
+      const axisDist = Math.abs(axis.y - component.cy);
+      const labelDist = Math.abs(label.y - component.cy);
+      expect(labelDist).toBeGreaterThan(axisDist);
+    });
+  });
+});

--- a/src/app/features/heroes/components/hero-stats/hero-stats.component.spec.ts
+++ b/src/app/features/heroes/components/hero-stats/hero-stats.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { HeroStatsComponent } from './hero-stats.component';
@@ -8,12 +9,15 @@ describe('HeroStatsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
       imports: [HeroStatsComponent]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(HeroStatsComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput("characters", ["Bruce Wayne"]);
+    fixture.componentRef.setInput("originators", ["Bob Kane"]);
     fixture.detectChanges();
   });
 

--- a/src/app/features/heroes/mappers/hero.mapper.spec.ts
+++ b/src/app/features/heroes/mappers/hero.mapper.spec.ts
@@ -1,0 +1,68 @@
+import { HeroMapper } from './hero.mapper';
+import { EPublisher } from '../../../core/models/enums/publisher.enum';
+import { DEFAULT_POWER_STATS, IHero } from '../../../core/models/interfaces/hero.interface';
+
+const MOCK_HERO: IHero = {
+  id: 'dc-batman',
+  key: 'dc-batman',
+  superhero: 'Batman',
+  publisher: EPublisher.DC,
+  alterEgo: 'Bruce Wayne',
+  firstAppearance: 'Detective Comics #27',
+  characters: ['Bruce Wayne'],
+  originators: ['Bob Kane'],
+  description: 'Dark Knight',
+  fileManager: { imgBg: 'bg.jpg', imgHero: 'hero.jpg', imgFA: 'fa.jpg' },
+  powerStats: DEFAULT_POWER_STATS,
+};
+
+describe('HeroMapper', () => {
+  describe('heroToHeroCard', () => {
+    it('should map id and title correctly', () => {
+      const card = HeroMapper.heroToHeroCard(MOCK_HERO);
+      expect(card.id).toBe('dc-batman');
+      expect(card.title).toBe('Batman');
+    });
+
+    it('should map fileManager images correctly', () => {
+      const card = HeroMapper.heroToHeroCard(MOCK_HERO);
+      expect(card.imgBg).toBe('bg.jpg');
+      expect(card.imgHero).toBe('hero.jpg');
+      expect(card.imgFront).toBe('fa.jpg');
+    });
+
+    it('should use fallback imgBg when fileManager is undefined', () => {
+      const card = HeroMapper.heroToHeroCard({ ...MOCK_HERO, fileManager: undefined });
+      expect(card.imgBg).toBe('no-image.jpg');
+    });
+
+    it('should use empty string for imgHero when fileManager is undefined', () => {
+      const card = HeroMapper.heroToHeroCard({ ...MOCK_HERO, fileManager: undefined });
+      expect(card.imgHero).toBe('');
+      expect(card.imgFront).toBe('');
+    });
+  });
+
+  describe('heroListToHeroCardList', () => {
+    it('should map a list of heroes to cards', () => {
+      const cards = HeroMapper.heroListToHeroCardList([MOCK_HERO, MOCK_HERO]);
+      expect(cards.length).toBe(2);
+      expect(cards[0].title).toBe('Batman');
+    });
+
+    it('should return empty array for empty list', () => {
+      expect(HeroMapper.heroListToHeroCardList([])).toEqual([]);
+    });
+
+    it('should return empty array when passed null', () => {
+      expect(HeroMapper.heroListToHeroCardList(null as any)).toEqual([]);
+    });
+
+    it('should preserve order of input list', () => {
+      const hero2: IHero = { ...MOCK_HERO, id: 'marvel-spider-man', superhero: 'Spider-Man' };
+      const cards = HeroMapper.heroListToHeroCardList([MOCK_HERO, hero2]);
+      expect(cards[0].title).toBe('Batman');
+      expect(cards[1].title).toBe('Spider-Man');
+    });
+  });
+});

--- a/src/app/features/heroes/pages/hero-detail/hero-detail.component.spec.ts
+++ b/src/app/features/heroes/pages/hero-detail/hero-detail.component.spec.ts
@@ -1,23 +1,55 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import { provideRouter, Router } from '@angular/router';
+import { Location } from '@angular/common';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import HeroDetailComponent from './hero-detail.component';
+import { HeroesService } from '../../services/heroes/heroes.service';
+import { of } from 'rxjs';
+import { DEFAULT_POWER_STATS, IHero } from '../../../../core/models/interfaces/hero.interface';
+import { EPublisher } from '../../../../core/models/enums/publisher.enum';
 
-import { HeroDetailComponent } from './hero-detail.component';
+const MOCK_HERO: IHero = {
+  id: 'dc-batman', key: 'dc-batman', superhero: 'Batman',
+  publisher: EPublisher.DC, alterEgo: 'Bruce Wayne',
+  firstAppearance: 'Detective Comics #27',
+  characters: ['Bruce Wayne'], originators: ['Bob Kane'],
+  description: 'Dark Knight', powerStats: DEFAULT_POWER_STATS,
+};
 
 describe('HeroDetailComponent', () => {
   let component: HeroDetailComponent;
   let fixture: ComponentFixture<HeroDetailComponent>;
+  let mockHeroesService: jasmine.SpyObj<HeroesService>;
 
   beforeEach(async () => {
+    mockHeroesService = jasmine.createSpyObj('HeroesService', ['getHeroById', 'delete']);
+    mockHeroesService.getHeroById.and.returnValue(of(MOCK_HERO));
+
     await TestBed.configureTestingModule({
-      imports: [HeroDetailComponent]
-    })
-    .compileComponents();
+      imports: [HeroDetailComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: HeroesService, useValue: mockHeroesService },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HeroDetailComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput('id', 'dc-batman');
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('editHero should navigate to edit route', () => {
+    const router = TestBed.inject(Router);
+    spyOn(router, 'navigate');
+    component.editHero();
+    expect(router.navigate).toHaveBeenCalledWith(['/heroes/edit', 'dc-batman']);
   });
 });

--- a/src/app/features/heroes/pages/hero-form/hero-form.component.spec.ts
+++ b/src/app/features/heroes/pages/hero-form/hero-form.component.spec.ts
@@ -1,23 +1,112 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { provideZonelessChangeDetection } from '@angular/core';
 import { HeroFormComponent } from './hero-form.component';
+import { provideRouter } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { HeroesService } from '../../services/heroes/heroes.service';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { MatChipInputEvent } from '@angular/material/chips';
 
 describe('HeroFormComponent', () => {
   let component: HeroFormComponent;
   let fixture: ComponentFixture<HeroFormComponent>;
+  let mockHeroesService: jasmine.SpyObj<HeroesService>;
 
   beforeEach(async () => {
+    mockHeroesService = jasmine.createSpyObj('HeroesService', ['getHeroById', 'add', 'update', 'delete']);
+
     await TestBed.configureTestingModule({
-      imports: [HeroFormComponent]
-    })
-    .compileComponents();
+      imports: [HeroFormComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: HeroesService, useValue: mockHeroesService },
+        { provide: ActivatedRoute, useValue: { snapshot: { paramMap: { get: () => null } } } },
+      ],
+    }).compileComponents();
 
     fixture = TestBed.createComponent(HeroFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it('should create in new mode', () => {
     expect(component).toBeTruthy();
+    expect(component.editing).toBeFalse();
+  });
+
+  describe('Form validation', () => {
+    it('should be invalid when empty', () => {
+      expect(component.heroForm.valid).toBeFalse();
+    });
+
+    it('should be valid with all required fields filled', () => {
+      component.heroForm.patchValue({
+        superhero: 'Green Arrow', publisher: 'DC',
+        alterEgo: 'Oliver Queen', firstAppearance: 'More Fun #73',
+      });
+      expect(component.heroForm.valid).toBeTrue();
+    });
+
+    it('should be invalid when superhero exceeds 20 characters', () => {
+      component.heroForm.patchValue({ superhero: 'A'.repeat(21) });
+      expect(component.heroForm.get('superhero')?.valid).toBeFalse();
+    });
+  });
+
+  describe('addChip()', () => {
+    it('should add a character keyword', () => {
+      const event = { value: 'Bruce Wayne', chipInput: { clear: jasmine.createSpy() } } as unknown as MatChipInputEvent;
+      component.addChip(event, 'character');
+      expect(component.charactersKeywords()).toContain('Bruce Wayne');
+    });
+
+    it('should not add duplicate character', () => {
+      const event = { value: 'Bruce Wayne', chipInput: { clear: jasmine.createSpy() } } as unknown as MatChipInputEvent;
+      component.addChip(event, 'character');
+      component.addChip(event, 'character');
+      expect(component.charactersKeywords().filter(k => k === 'Bruce Wayne').length).toBe(1);
+    });
+
+    it('should add an originator keyword', () => {
+      const event = { value: 'Bob Kane', chipInput: { clear: jasmine.createSpy() } } as unknown as MatChipInputEvent;
+      component.addChip(event, 'originator');
+      expect(component.originatorsKeywords()).toContain('Bob Kane');
+    });
+
+    it('should ignore empty values', () => {
+      const event = { value: '   ', chipInput: { clear: jasmine.createSpy() } } as unknown as MatChipInputEvent;
+      component.addChip(event, 'character');
+      expect(component.charactersKeywords().length).toBe(0);
+    });
+  });
+
+  describe('removeChip()', () => {
+    it('should remove a character', () => {
+      component.charactersKeywords.set(['Bruce Wayne', 'Terry McGinnis']);
+      component.removeChip('Bruce Wayne', 'character');
+      expect(component.charactersKeywords()).not.toContain('Bruce Wayne');
+      expect(component.charactersKeywords()).toContain('Terry McGinnis');
+    });
+
+    it('should remove an originator', () => {
+      component.originatorsKeywords.set(['Bob Kane', 'Bill Finger']);
+      component.removeChip('Bob Kane', 'originator');
+      expect(component.originatorsKeywords()).not.toContain('Bob Kane');
+      expect(component.originatorsKeywords()).toContain('Bill Finger');
+    });
+  });
+
+  describe('generateId()', () => {
+    it('should build id from publisher and superhero', () => {
+      component.heroForm.patchValue({ publisher: 'DC', superhero: 'Green Arrow' });
+      expect(component.generateId()).toBe('dc-green-arrow');
+    });
+
+    it('should handle spaces in superhero name', () => {
+      component.heroForm.patchValue({ publisher: 'Marvel', superhero: 'Spider Man' });
+      expect(component.generateId()).toBe('marvel-spider-man');
+    });
   });
 });

--- a/src/app/features/heroes/pages/heroes-list/heroes-list.component.spec.ts
+++ b/src/app/features/heroes/pages/heroes-list/heroes-list.component.spec.ts
@@ -1,23 +1,129 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
+import HeroesListPageComponent from './heroes-list.component';
+import { provideRouter } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
+import { HeroesService } from '../../services/heroes/heroes.service';
+import { EPublisher } from '../../../../core/models/enums/publisher.enum';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { of } from 'rxjs';
 
-import { HeroesListComponent } from './heroes-list.component';
-
-describe('HeroesListComponent', () => {
-  let component: HeroesListComponent;
-  let fixture: ComponentFixture<HeroesListComponent>;
+describe('HeroesListPageComponent', () => {
+  let component: HeroesListPageComponent;
+  let fixture: ComponentFixture<HeroesListPageComponent>;
+  let mockHeroesService: jasmine.SpyObj<HeroesService>;
 
   beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      imports: [HeroesListComponent]
-    })
-    .compileComponents();
+    mockHeroesService = jasmine.createSpyObj('HeroesService', ['getFilteredHeroCards']);
+    mockHeroesService.getFilteredHeroCards.and.returnValue(of([]));
 
-    fixture = TestBed.createComponent(HeroesListComponent);
+    await TestBed.configureTestingModule({
+      imports: [HeroesListPageComponent],
+      providers: [
+        provideZonelessChangeDetection(),
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: HeroesService, useValue: mockHeroesService },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams: {} } } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeroesListPageComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('hasActiveFilters()', () => {
+    it('should be false initially', () => {
+      expect(component.hasActiveFilters()).toBeFalse();
+    });
+
+    it('should be true after setting searchTerm', () => {
+      component.searchTerm.set('batman');
+      expect(component.hasActiveFilters()).toBeTrue();
+    });
+
+    it('should be true after selecting a publisher', () => {
+      component.selectedPublisher.set(EPublisher.Marvel);
+      expect(component.hasActiveFilters()).toBeTrue();
+    });
+
+    it('should be true after setting nameFilter', () => {
+      component.nameFilter.set('bat');
+      expect(component.hasActiveFilters()).toBeTrue();
+    });
+  });
+
+  describe('clearSearch()', () => {
+    it('should reset searchTerm to empty string', () => {
+      component.searchTerm.set('batman');
+      component.clearSearch();
+      expect(component.searchTerm()).toBe('');
+    });
+  });
+
+  describe('clearAllFilters()', () => {
+    it('should reset all filters', () => {
+      component.searchTerm.set('batman');
+      component.selectedPublisher.set(EPublisher.Marvel);
+      component.nameFilter.set('bat');
+      component.alterEgoFilter.set('bruce');
+      component.clearAllFilters();
+      expect(component.hasActiveFilters()).toBeFalse();
+    });
+  });
+
+  describe('selectPublisher()', () => {
+    it('should set publisher when not selected', () => {
+      component.selectPublisher(EPublisher.DC);
+      expect(component.selectedPublisher()).toBe(EPublisher.DC);
+    });
+
+    it('should toggle back to all when already selected', () => {
+      component.selectedPublisher.set(EPublisher.DC);
+      component.selectPublisher(EPublisher.DC);
+      expect(component.selectedPublisher()).toBe('all');
+    });
+  });
+
+  describe('isPublisherSelected()', () => {
+    it('should return true when publisher matches', () => {
+      component.selectedPublisher.set(EPublisher.Marvel);
+      expect(component.isPublisherSelected(EPublisher.Marvel)).toBeTrue();
+    });
+
+    it('should return false when publisher does not match', () => {
+      component.selectedPublisher.set(EPublisher.DC);
+      expect(component.isPublisherSelected(EPublisher.Marvel)).toBeFalse();
+    });
+  });
+
+  describe('advancedFiltersCount()', () => {
+    it('should be 0 with no advanced filters', () => {
+      expect(component.advancedFiltersCount()).toBe(0);
+    });
+
+    it('should count each active advanced filter', () => {
+      component.nameFilter.set('bat');
+      expect(component.advancedFiltersCount()).toBe(1);
+      component.alterEgoFilter.set('bruce');
+      expect(component.advancedFiltersCount()).toBe(2);
+      component.originatorFilter.set('kane');
+      expect(component.advancedFiltersCount()).toBe(3);
+    });
+  });
+
+  describe('clearAdvancedFilters()', () => {
+    it('should reset nameFilter, alterEgoFilter and originatorFilter', () => {
+      component.nameFilter.set('bat');
+      component.alterEgoFilter.set('bruce');
+      component.originatorFilter.set('kane');
+      component.clearAdvancedFilters();
+      expect(component.advancedFiltersCount()).toBe(0);
+    });
   });
 });

--- a/src/app/features/heroes/pipes/ascending-order/ascending-order.pipe.spec.ts
+++ b/src/app/features/heroes/pipes/ascending-order/ascending-order.pipe.spec.ts
@@ -1,8 +1,37 @@
 import { AscendingOrderPipe } from './ascending-order.pipe';
 
 describe('AscendingOrderPipe', () => {
-  it('create an instance', () => {
-    const pipe = new AscendingOrderPipe();
+  let pipe: AscendingOrderPipe;
+
+  beforeEach(() => {
+    pipe = new AscendingOrderPipe();
+  });
+
+  it('should create an instance', () => {
     expect(pipe).toBeTruthy();
+  });
+
+  it('should sort array alphabetically', () => {
+    expect(pipe.transform(['Charlie', 'Alice', 'Bob'])).toBe('Alice, Bob, Charlie');
+  });
+
+  it('should return single item without separator', () => {
+    expect(pipe.transform(['Solo'])).toBe('Solo');
+  });
+
+  it('should return empty string for empty array', () => {
+    expect(pipe.transform([])).toBe('');
+  });
+
+  it('should sort case-sensitively (uppercase before lowercase)', () => {
+    const result = pipe.transform(['bob', 'Alice']);
+    expect(result).toBe('Alice, bob');
+  });
+
+  it('should join multiple items with comma and space', () => {
+    const result = pipe.transform(['Z', 'A', 'M']);
+    expect(result).toContain(', ');
+    expect(result.startsWith('A')).toBeTrue();
+    expect(result.endsWith('Z')).toBeTrue();
   });
 });

--- a/src/app/features/heroes/services/heroes/heroes.service.spec.ts
+++ b/src/app/features/heroes/services/heroes/heroes.service.spec.ts
@@ -1,39 +1,83 @@
 import { TestBed } from '@angular/core/testing';
-import {
-  HttpTestingController,
-  provideHttpClientTesting,
-} from '@angular/common/http/testing';
+import { provideZonelessChangeDetection } from '@angular/core';
 import { HeroesService } from './heroes.service';
-import {
-  provideHttpClient,
-  withInterceptorsFromDi,
-} from '@angular/common/http';
+import { EPublisher } from '../../../../core/models/enums/publisher.enum';
+import { DEFAULT_POWER_STATS, IHero } from '../../../../core/models/interfaces/hero.interface';
 
-describe('ServicesService', () => {
-  let httpTestingController: HttpTestingController;
+const MOCK_HERO: IHero = {
+  id: 'dc-batman', key: 'dc-batman', superhero: 'Batman',
+  publisher: EPublisher.DC, alterEgo: 'Bruce Wayne',
+  firstAppearance: 'Detective Comics #27',
+  characters: ['Bruce Wayne'], originators: ['Bob Kane'],
+  description: 'Dark Knight', powerStats: DEFAULT_POWER_STATS,
+};
+
+describe('HeroesService', () => {
   let service: HeroesService;
-  let baseUrl = 'http://localhost:4200/heroes';
+  let db: any;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({
-      imports: [],
-      providers: [
-        provideHttpClient(withInterceptorsFromDi()),
-        provideHttpClientTesting(),
-      ],
-    });
-
-    httpTestingController = TestBed.inject(HttpTestingController);
+    TestBed.configureTestingModule({ providers: [provideZonelessChangeDetection()] });
     service = TestBed.inject(HeroesService);
+    db = (service as any).db;
   });
 
-  afterEach(() => {
-    httpTestingController.verify();
+  it('should be created', () => { expect(service).toBeTruthy(); });
+
+  describe('getAll()', () => {
+    it('should return heroes from db', (done) => {
+      spyOn(db.heroes, 'toArray').and.returnValue(Promise.resolve([MOCK_HERO]));
+      service.getAll().subscribe(heroes => {
+        expect(heroes.length).toBe(1);
+        expect(heroes[0].superhero).toBe('Batman');
+        done();
+      });
+    });
+    it('should return empty array when no heroes', (done) => {
+      spyOn(db.heroes, 'toArray').and.returnValue(Promise.resolve([]));
+      service.getAll().subscribe(heroes => { expect(heroes).toEqual([]); done(); });
+    });
   });
 
-  it('Should bew creted correcly', () => {
-    expect(service).toBeTruthy();
+  describe('getHeroById()', () => {
+    it('should return hero when found', (done) => {
+      spyOn(db.heroes, 'get').and.returnValue(Promise.resolve(MOCK_HERO));
+      service.getHeroById('dc-batman').subscribe(hero => {
+        expect(hero.id).toBe('dc-batman'); done();
+      });
+    });
+    it('should throw error when hero not found', (done) => {
+      spyOn(db.heroes, 'get').and.returnValue(Promise.resolve(undefined));
+      service.getHeroById('nonexistent').subscribe({ error: (err: Error) => { expect(err.message).toContain('not found'); done(); } });
+    });
   });
 
-  describe('Testing the tests that call the backend', () => {});
+  describe('add()', () => {
+    it('should call db.heroes.add and return the id', (done) => {
+      spyOn(db.heroes, 'add').and.returnValue(Promise.resolve('dc-batman'));
+      service.add(MOCK_HERO).subscribe(id => {
+        expect(db.heroes.add).toHaveBeenCalledWith(MOCK_HERO);
+        expect(id).toBe('dc-batman'); done();
+      });
+    });
+  });
+
+  describe('update()', () => {
+    it('should call db.heroes.update with correct args', (done) => {
+      spyOn(db.heroes, 'update').and.returnValue(Promise.resolve(1));
+      service.update('dc-batman', { superhero: 'Batman Updated' }).subscribe(count => {
+        expect(db.heroes.update).toHaveBeenCalledWith('dc-batman', { superhero: 'Batman Updated' });
+        expect(count).toBe(1); done();
+      });
+    });
+  });
+
+  describe('delete()', () => {
+    it('should call db.heroes.delete with the id', (done) => {
+      spyOn(db.heroes, 'delete').and.returnValue(Promise.resolve());
+      service.delete('dc-batman').subscribe(() => {
+        expect(db.heroes.delete).toHaveBeenCalledWith('dc-batman'); done();
+      });
+    });
+  });
 });

--- a/src/app/features/init/init.component.spec.ts
+++ b/src/app/features/init/init.component.spec.ts
@@ -1,4 +1,6 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { InitComponent } from './init.component';
 
@@ -8,6 +10,7 @@ describe('InitComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection(), provideRouter([])],
       imports: [InitComponent]
     })
     .compileComponents();

--- a/src/app/shared/pipes/clean-text/clean-text.pipe.spec.ts
+++ b/src/app/shared/pipes/clean-text/clean-text.pipe.spec.ts
@@ -1,8 +1,42 @@
 import { CleanTextPipe } from './clean-text.pipe';
 
 describe('CleanTextPipe', () => {
-  it('create an instance', () => {
-    const pipe = new CleanTextPipe();
+  let pipe: CleanTextPipe;
+
+  beforeEach(() => {
+    pipe = new CleanTextPipe();
+  });
+
+  it('should create an instance', () => {
     expect(pipe).toBeTruthy();
+  });
+
+  it('should keep alphanumeric characters and spaces', () => {
+    expect(pipe.transform('Batman 123')).toBe('Batman 123');
+  });
+
+  it('should keep accented characters', () => {
+    expect(pipe.transform('héroe')).toBe('héroe');
+  });
+
+  it('should keep ñ and Ñ', () => {
+    expect(pipe.transform('España')).toBe('España');
+  });
+
+  it('should replace special characters with a single space', () => {
+    expect(pipe.transform('A--B')).toBe('A B');
+  });
+
+  it('should not produce consecutive spaces from multiple special chars', () => {
+    const result = pipe.transform('A!!!B') as string;
+    expect(result).toBe('A B');
+  });
+
+  it('should trim leading and trailing spaces from special chars', () => {
+    expect(pipe.transform('!hello!')).toBe('hello');
+  });
+
+  it('should handle empty string', () => {
+    expect(pipe.transform('')).toBe('');
   });
 });

--- a/src/app/shared/ui/card/card.component.spec.ts
+++ b/src/app/shared/ui/card/card.component.spec.ts
@@ -1,3 +1,4 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { CardComponent } from './card.component';
@@ -8,12 +9,16 @@ describe('CardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection()],
       imports: [CardComponent]
     })
     .compileComponents();
 
     fixture = TestBed.createComponent(CardComponent);
     component = fixture.componentInstance;
+    fixture.componentRef.setInput("id", "dc-batman");
+    fixture.componentRef.setInput("imgBG", "bg.jpg");
+    fixture.componentRef.setInput("title", "Batman");
     fixture.detectChanges();
   });
 

--- a/src/app/shared/ui/navbar/navbar.component.spec.ts
+++ b/src/app/shared/ui/navbar/navbar.component.spec.ts
@@ -1,4 +1,6 @@
+import { provideZonelessChangeDetection } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { NavbarComponent } from './navbar.component';
 
@@ -8,6 +10,7 @@ describe('NavbarComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      providers: [provideZonelessChangeDetection(), provideRouter([])],
       imports: [NavbarComponent]
     })
     .compileComponents();


### PR DESCRIPTION
## Summary
- HeroModel, HeroMapper, AscendingOrderPipe, CleanTextPipe — pure unit tests
- HeroesService — spy on Dexie db (getAll, getHeroById, add, update, delete)
- HeroesListPageComponent — filters, hasActiveFilters, clearAll, selectPublisher toggle
- HeroFormComponent — validation, addChip/removeChip dedup, generateId
- HeroDetailComponent — create, editHero navigation
- HeroRadarChartComponent — gridPolygon, statPolygon reactivity, axisEnd, labelPos
- All pre-existing stubs fixed: provideZonelessChangeDetection, required inputs, Router
- Added @angular/animations dependency (required by Material in tests)
- New script: `npm run test:coverage` (headless + coverage report)

## Results
91/91 tests passing | 70% statement coverage | 60% branch coverage

## Test plan
- [ ] Run `npm test` -> all green
- [ ] Run `npm run test:coverage` -> opens coverage/heroes/index.html

Generated with Claude Code