### PR TITLE
ci(#11): split pipeline into ci-develop and ci-main

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -1,10 +1,8 @@
-name: CI
+name: CI — develop
 
 on:
   pull_request:
-    branches: [develop, main]
-  push:
-    branches: [develop, main]
+    branches: [develop]
 
 jobs:
   build:
@@ -43,7 +41,6 @@ jobs:
           cache: 'npm'
 
       - name: Install Chrome
-        id: setup-chrome
         uses: browser-actions/setup-chrome@v1
 
       - name: Install dependencies

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,0 +1,70 @@
+name: CI — main
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Build
+        run: npm run build
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+
+      - name: Install dependencies
+        run: npm install --legacy-peer-deps
+
+      - name: Test (headless CI)
+        run: npm run test:ci
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+    needs: test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: E2E tests (not yet implemented)
+        run: echo "E2E tests pending implementation"


### PR DESCRIPTION
## Summary
- Remove generic `ci.yml`
- Add `ci-develop.yml`: build + test, triggered only on PR to `develop`
- Add `ci-main.yml`: build + test + e2e (placeholder), triggered only on PR to `main`
- Branch protection rules configured separately

?? Generated with [Claude Code](https://claude.com/claude-code)