### PR TITLE
IHT-29: harden CI permissions + ignore local AI tooling files

### DIFF
--- a/.github/workflows/ci-develop.yml
+++ b/.github/workflows/ci-develop.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [develop]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -41,7 +44,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build
@@ -41,7 +44,7 @@ jobs:
           cache: 'npm'
 
       - name: Install Chrome
-        uses: browser-actions/setup-chrome@v1
+        uses: browser-actions/setup-chrome@c785b87e244131f27c9f19c1a33e2ead956ab7ce # v1
 
       - name: Install dependencies
         run: npm install --legacy-peer-deps

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,9 @@ Thumbs.db
 # Playwright
 playwright-report/
 test-results/
+
+# Claude / AI tooling — local only, never commit
+CLAUDE.md
+.claudeignore
+.claude/
+AGENTS.md


### PR DESCRIPTION
## Summary
- Restrict CI workflow permissions to `contents: read`, pin `browser-actions` to SHA
- Exclude local AI tool config files (CLAUDE.md, .claudeignore, .claude/, AGENTS.md) from version control

## Test plan
- [x] Build + unit tests pass